### PR TITLE
Zodバリデーションを追加（Hono + Zod middlewareでバリデーション）

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -6,7 +6,9 @@
     "cf-typegen": "wrangler types --env-interface CloudflareBindings"
   },
   "dependencies": {
-    "hono": "^4.7.10"
+    "@hono/zod-validator": "^0.5.0",
+    "hono": "^4.7.10",
+    "zod": "^3.25.30"
   },
   "devDependencies": {
     "wrangler": "^4.4.0"

--- a/apps/backend/src/index.ts
+++ b/apps/backend/src/index.ts
@@ -1,5 +1,7 @@
+import { zValidator } from "@hono/zod-validator";
 import { Hono } from "hono";
 import { cors } from "hono/cors";
+import z from "zod";
 
 const app = new Hono();
 
@@ -10,9 +12,27 @@ app.use(
   })
 );
 
-const route = app.get("/hello", (c) => {
-  return c.json({ message: "hello world" });
+const todoSchema = z.object({
+  title: z.string().min(2),
+  desc: z.string().nullable(),
 });
+
+const route = app
+  .get("/hello", (c) => {
+    return c.json({ message: "hello world" });
+  })
+  .post(
+    "/todo",
+    zValidator("json", todoSchema, (result, c) => {
+      if (!result.success) {
+        return c.text(result.error.issues[0].message, 400);
+      }
+    }),
+    (c) => {
+      const { title, desc } = c.req.valid("json");
+      return c.json({ title, desc });
+    }
+  );
 
 export type AppType = typeof route;
 

--- a/apps/frontend/src/app/page.tsx
+++ b/apps/frontend/src/app/page.tsx
@@ -1,15 +1,55 @@
 "use client";
 import { client } from "@/utils/client";
+import { useActionState } from "react";
 
 export default function Home() {
-  const handleClick = async () => {
-    const res = await client.hello.$get();
-    const data = await res.json();
-    alert(data.message);
+  const formAction = async (prevError: string | null, formData: FormData) => {
+    const title = formData.get("title") as string;
+    const desc = formData.get("desc") as string;
+    const res = await client.todo.$post({
+      json: { title, desc },
+    });
+    if (!res.ok) {
+      const error = await res.text();
+      return error;
+    }
+    return null;
   };
+
+  const [error, submitAction, isPending] = useActionState(formAction, null);
+
   return (
-    <div>
-      <button onClick={handleClick}>Hello</button>
+    <div className="mt-10">
+      <h1 className="text-3xl font-bold text-center">Todo</h1>
+      <form
+        action={submitAction}
+        className="flex flex-col gap-2 max-w-[600px] mx-auto mt-10"
+      >
+        <label htmlFor="title" className="text-sm font-medium">
+          Title
+        </label>
+        <input
+          type="text"
+          name="title"
+          className="border-2 border-gray-300 rounded-md p-2"
+        />
+        <label htmlFor="description" className="text-sm font-medium">
+          Description
+        </label>
+        <input
+          type="text"
+          name="description"
+          className="border-2 border-gray-300 rounded-md p-2"
+        />
+        <button
+          disabled={isPending}
+          type="submit"
+          className="bg-blue-500 text-white p-2 rounded-md"
+        >
+          Submit
+        </button>
+        {error && <p className="text-red-500">{error}</p>}
+      </form>
     </div>
   );
 }

--- a/bun.lock
+++ b/bun.lock
@@ -7,7 +7,9 @@
     "apps/backend": {
       "name": "backend",
       "dependencies": {
+        "@hono/zod-validator": "^0.5.0",
         "hono": "^4.7.10",
+        "zod": "^3.25.30",
       },
       "devDependencies": {
         "wrangler": "^4.4.0",
@@ -132,6 +134,8 @@
     "@eslint/plugin-kit": ["@eslint/plugin-kit@0.3.1", "", { "dependencies": { "@eslint/core": "^0.14.0", "levn": "^0.4.1" } }, "sha512-0J+zgWxHN+xXONWIyPWKFMgVuJoZuGiIFu8yxk7RJjxkzpGmyja5wRFqZIVtjDVOQpV+Rw0iOAjYPE2eQyjr0w=="],
 
     "@fastify/busboy": ["@fastify/busboy@2.1.1", "", {}, "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA=="],
+
+    "@hono/zod-validator": ["@hono/zod-validator@0.5.0", "", { "peerDependencies": { "hono": ">=3.9.0", "zod": "^3.19.1" } }, "sha512-ds5bW6DCgAnNHP33E3ieSbaZFd5dkV52ZjyaXtGoR06APFrCtzAsKZxTHwOrJNBdXsi0e5wNwo5L4nVEVnJUdg=="],
 
     "@humanfs/core": ["@humanfs/core@0.19.1", "", {}, "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA=="],
 
@@ -933,7 +937,7 @@
 
     "youch": ["youch@3.3.4", "", { "dependencies": { "cookie": "^0.7.1", "mustache": "^4.2.0", "stacktracey": "^2.1.8" } }, "sha512-UeVBXie8cA35DS6+nBkls68xaBBXCye0CNznrhszZjTbRVnJKQuNsyLKBTTL4ln1o1rh2PKtv35twV7irj5SEg=="],
 
-    "zod": ["zod@3.22.3", "", {}, "sha512-EjIevzuJRiRPbVH4mGc8nApb/lVLKVpmUhAaR5R5doKGfAnGJ6Gr3CViAVjP+4FWSxCsybeWQdcgCtbX+7oZug=="],
+    "zod": ["zod@3.25.30", "", {}, "sha512-VolhdEtu6TJr/fzGuHA/SZ5ixvXqA6ADOG9VRcQ3rdOKmF5hkmcJbyaQjUH5BgmpA9gej++zYRX7zjSmdReIwA=="],
 
     "@ampproject/remapping/@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.25", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ=="],
 
@@ -980,6 +984,8 @@
     "frontend/backend": ["backend@0.0.0", "", {}, "sha512-Fq2aG5+zmmsKv2Dhm3ijAU5spnKOb5ldJlnnC/Vhk6n8In6zaq9eCPBMRiz2j94P/r84QEaBmtwh9tjaDPiQqg=="],
 
     "micromatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
+
+    "miniflare/zod": ["zod@3.22.3", "", {}, "sha512-EjIevzuJRiRPbVH4mGc8nApb/lVLKVpmUhAaR5R5doKGfAnGJ6Gr3CViAVjP+4FWSxCsybeWQdcgCtbX+7oZug=="],
 
     "next/postcss": ["postcss@8.4.31", "", { "dependencies": { "nanoid": "^3.3.6", "picocolors": "^1.0.0", "source-map-js": "^1.0.2" } }, "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ=="],
 


### PR DESCRIPTION
## 実装内容

### zodをインストール
- コマンド：`bun add zod @hono/zod-validator`

### zod検証

#### バックエンド
- titleとdescriptionを受け取るtodoというエンドポイントを作成

#### フロント
- `useActionState`を使用して、簡単な入力フォームと送信ボタンを作成

#### 検証
- 空文字で送信すると、バリデーションが通らず、Zodが生成するエラーメッセージが表示されることを確認

![image](https://github.com/user-attachments/assets/edd9e026-c9cb-4b1a-8b36-1a20a7c47aa7)
