### PR TITLE
profileAPIの作成

### DIFF
--- a/apps/backend/src/utils/supabase/client.ts
+++ b/apps/backend/src/utils/supabase/client.ts
@@ -1,0 +1,15 @@
+import { createClient } from "@supabase/supabase-js";
+
+export function createSupabaseClientWithToken(token: string) {
+  return createClient(
+    process.env.SUPABASE_URL!,
+    process.env.SUPABASE_ANON_KEY!,
+    {
+      global: {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      },
+    }
+  );
+}

--- a/apps/frontend/src/app/setProfile/action.ts
+++ b/apps/frontend/src/app/setProfile/action.ts
@@ -1,0 +1,25 @@
+"use server";
+import { getHonoClient } from "@/utils/client";
+import { getToken } from "@/utils/utils";
+import { redirect } from "next/navigation";
+
+export const setUserName = async (name: string) => {
+  const token = await getToken();
+  if (token == null)
+    return {
+      success: false,
+      message: "ログインしてください",
+    };
+  const client = getHonoClient(token);
+  const res = await client.profile.$post({
+    json: { name },
+  });
+  if (!res.ok) {
+    const error = await res.text();
+    return {
+      success: false,
+      message: error || "ニックネームの登録に失敗しました。",
+    };
+  }
+  redirect("/");
+};

--- a/apps/frontend/src/app/setProfile/page.tsx
+++ b/apps/frontend/src/app/setProfile/page.tsx
@@ -1,0 +1,45 @@
+"use client";
+import React, { useActionState } from "react";
+import { setUserName } from "./action";
+
+export default function SetProfilePage() {
+  const profileAction = async (
+    preverror: string | null,
+    formData: FormData
+  ): Promise<string | null> => {
+    const name = formData.get("name") as string;
+    const res = await setUserName(name);
+    if (!res.success) {
+      console.error("signup、失敗", res.message);
+      return res.message || "サインインに失敗しました。";
+    }
+    return null;
+  };
+
+  const [error, submitAction, isPending] = useActionState(profileAction, null);
+
+  return (
+    <div className="flex flex-col items-center justify-center h-screen">
+      <h1 className="text-3xl font-bold mb-4">ニックネームを決めよう！</h1>
+      <form action={submitAction} className="flex flex-col space-y-4 min-w-3xl">
+        <label className="font-semibold" htmlFor="name">
+          ニックネーム
+        </label>
+        <input
+          name="name"
+          type="text"
+          required
+          className="border border-gray-300 p-2 rounded"
+        />
+        <button
+          disabled={isPending}
+          type="submit"
+          className="bg-green-500 text-white p-2 rounded hover:bg-green-600"
+        >
+          決定
+        </button>
+        {error && <p className="text-red-500">{error}</p>}
+      </form>
+    </div>
+  );
+}

--- a/apps/frontend/src/app/signup/actions.ts
+++ b/apps/frontend/src/app/signup/actions.ts
@@ -1,5 +1,4 @@
 "use server";
-import { revalidatePath } from "next/cache";
 import { redirect } from "next/navigation";
 
 import { createClient } from "@/utils/supabase/server";
@@ -14,20 +13,5 @@ export const supabaseSignup = async (email: string, password: string) => {
       message: error.message || "サインインに失敗しました。",
     };
   }
-  revalidatePath("/", "layout");
-  redirect("/");
+  redirect("/setProfile");
 };
-// export const signup = async (email: string, password: string) => {
-//   try {
-//     const res = await client.signup.$post({
-//       json: { email, password },
-//     });
-//     if (!res.ok) {
-//       const error = await res.text();
-//       return error;
-//     }
-//     return res.json();
-//   } catch (e) {
-//     throw e;
-//   }
-// };

--- a/apps/frontend/src/utils/client.ts
+++ b/apps/frontend/src/utils/client.ts
@@ -1,4 +1,13 @@
 import { hc } from "hono/client";
 import { AppType } from "backend/src";
 
-export const client = hc<AppType>(process.env.NEXT_PUBLIC_API_URL!);
+export const getHonoClient = (accessToken: string) => {
+  const headers: HeadersInit = {
+    "Content-Type": "application/json",
+  };
+  if (accessToken) {
+    headers["Authorization"] = `Bearer ${accessToken}`;
+  }
+  return hc<AppType>(process.env.NEXT_PUBLIC_API_URL!, { headers });
+};
+// export const client = hc<AppType>(process.env.NEXT_PUBLIC_API_URL!);

--- a/apps/frontend/src/utils/utils.ts
+++ b/apps/frontend/src/utils/utils.ts
@@ -1,0 +1,10 @@
+import { createClient } from "@/utils/supabase/server";
+
+export const getToken = async () => {
+  const supabase = await createClient();
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+  const token = session?.access_token;
+  return token;
+};


### PR DESCRIPTION
## 実装内容

- profileAPIの作成
- ニックネームの登録を行い、profileテーブルへの登録も行う（既に登録されている場合は登録できないように）
- この時、supabse-authとのリレーションが接続されていることを確認
- profileAPIを叩く際にAPIに認証のミドルウェアを設定

