### PR TITLE
api呼び出しに認証追加と、フロントのapi呼ぶロジックを修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,8 +76,16 @@ bunx drizzle-kit migrate
 ```
 
 5.  **開発サーバーを起動します:**
+
     ```bash
     cd apps/backend && bun run dev
     cd apps/frontend && bun run dev
     ```
+
     アプリケーションは `http://localhost:3000` で利用可能になります。
+
+6.  **Cloudflare Pages へのデプロイ**
+
+    ```bash
+    bun install && bun run build"
+    ```

--- a/apps/frontend/src/app/setProfile/action.ts
+++ b/apps/frontend/src/app/setProfile/action.ts
@@ -1,16 +1,9 @@
 "use server";
-import { getHonoClient } from "@/utils/client";
-import { getToken } from "@/utils/utils";
+import { createAuthorizedClient } from "@/utils/client";
 import { redirect } from "next/navigation";
 
 export const setUserName = async (name: string) => {
-  const token = await getToken();
-  if (token == null)
-    return {
-      success: false,
-      message: "ログインしてください",
-    };
-  const client = getHonoClient(token);
+  const client = await createAuthorizedClient();
   const res = await client.profile.$post({
     json: { name },
   });

--- a/apps/frontend/src/components/Todos.tsx
+++ b/apps/frontend/src/components/Todos.tsx
@@ -1,24 +1,34 @@
 "use client";
-import { client } from "@/utils/client";
-import { useQuery } from "@tanstack/react-query";
-
-const getTodos = async () => {
-  const res = await client.todos.$get();
-  const { todos } = await res.json();
-  return todos;
-};
+import { useGetTodos } from "@/features/todos/api/use-get-todos";
 
 export const Todos = () => {
-  const query = useQuery({ queryKey: ["todos"], queryFn: getTodos });
+  const { data, isLoading } = useGetTodos();
+
+  if (isLoading) {
+    return (
+      <div className="w-full mt-72 flex justify-center items-center">
+        loading...
+      </div>
+    );
+  }
+  if (!data) {
+    return (
+      <div className="w-full mt-64 flex justify-center items-center">
+        todoが見つかりません
+      </div>
+    );
+  }
   return (
     <div className="pb-10">
-      {query.data?.map((todo) => (
+      {data.todos.map((todo) => (
         <div
           key={todo.id}
           className="max-w-[600px] mx-auto mt-4 p-4 bg-white rounded-lg shadow-md hover:shadow-lg transition-shadow"
         >
           <h3 className="text-lg font-semibold text-gray-800">{todo.title}</h3>
-          {todo.desc && <p className="mt-2 text-gray-600">{todo.desc}</p>}
+          {todo.description && (
+            <p className="mt-2 text-gray-600">{todo.description}</p>
+          )}
         </div>
       ))}
     </div>

--- a/apps/frontend/src/features/todos/action.ts
+++ b/apps/frontend/src/features/todos/action.ts
@@ -1,0 +1,30 @@
+"use server";
+import {
+  TodoPostRequest,
+  TodoPostResponse,
+  TodosGetResponse,
+} from "@/types/api";
+import { createAuthorizedClient } from "@/utils/client";
+
+// Todo取得
+export const getTodoList = async (): Promise<TodosGetResponse> => {
+  const client = await createAuthorizedClient();
+  const response = await client.todos.$get();
+  if (!response.ok) {
+    throw new Error("記事の取得に失敗しました");
+  }
+  return response.json();
+};
+// Todo作成
+export const createTodo = async (
+  newTodo: TodoPostRequest
+): Promise<TodoPostResponse> => {
+  const client = await createAuthorizedClient();
+  const response = await client.todos.$post({
+    json: newTodo,
+  });
+  if (!response.ok) {
+    throw new Error("記事の取得に失敗しました");
+  }
+  return response.json();
+};

--- a/apps/frontend/src/features/todos/api/use-create-todos.ts
+++ b/apps/frontend/src/features/todos/api/use-create-todos.ts
@@ -1,0 +1,26 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { createTodo } from "../action";
+import { TodoPostResponse } from "@/types/api";
+
+// mutationFnに渡す変数の型を定義
+// IDはmutationFn内で生成するため、ここではtitleとdescriptionのみ
+type CreateTodoVariables = {
+  title: string;
+  description: string;
+};
+
+export const useCreateTodo = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation<TodoPostResponse, Error, CreateTodoVariables>({
+    mutationFn: async (variables: { title: string; description: string }) => {
+      const id = crypto.randomUUID();
+      const newTodoData = { ...variables, id };
+      const response = await createTodo(newTodoData);
+      return response;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["todos"] });
+    },
+  });
+};

--- a/apps/frontend/src/features/todos/api/use-get-todos.ts
+++ b/apps/frontend/src/features/todos/api/use-get-todos.ts
@@ -1,0 +1,14 @@
+import { useQuery } from "@tanstack/react-query";
+import { getTodoList } from "../action";
+import { TodosGetResponse } from "@/types/api";
+
+export const useGetTodos = () => {
+  const query = useQuery<TodosGetResponse, Error>({
+    queryKey: ["todos"],
+    queryFn: async () => {
+      const todos = await getTodoList();
+      return todos;
+    },
+  });
+  return query;
+};

--- a/apps/frontend/src/types/api.ts
+++ b/apps/frontend/src/types/api.ts
@@ -1,0 +1,13 @@
+import { client } from "@/utils/client";
+import { InferResponseType, InferRequestType } from "hono";
+
+// 例：Todo作成APIのレスポンスボディの型
+export type TodoPostResponse = InferResponseType<typeof client.todos.$post>;
+
+// 例：Todo作成APIのリクエストボディ（`json`）の型
+export type TodoPostRequest = InferRequestType<
+  typeof client.todos.$post
+>["json"];
+
+// 例：全Todo取得APIのレスポンスボディの型
+export type TodosGetResponse = InferResponseType<typeof client.todos.$get>;

--- a/apps/frontend/src/utils/client.ts
+++ b/apps/frontend/src/utils/client.ts
@@ -1,13 +1,20 @@
 import { hc } from "hono/client";
 import { AppType } from "backend/src";
+import { getToken } from "./utils";
 
-export const getHonoClient = (accessToken: string) => {
+// 認証あり
+export const createAuthorizedClient = async () => {
+  const accessToken = await getToken();
+  if (!accessToken) {
+    throw new Error("ログインしてください");
+  }
+
   const headers: HeadersInit = {
     "Content-Type": "application/json",
+    Authorization: `Bearer ${accessToken}`,
   };
-  if (accessToken) {
-    headers["Authorization"] = `Bearer ${accessToken}`;
-  }
-  return hc<AppType>(process.env.NEXT_PUBLIC_API_URL!, { headers });
+
+  return hc<AppType>(process.env.API_URL!, { headers });
 };
-// export const client = hc<AppType>(process.env.NEXT_PUBLIC_API_URL!);
+// 認証なし　型の宣言用
+export const client = hc<AppType>(process.env.API_URL!);


### PR DESCRIPTION
##実装内容

## バックエンド

- APIのミドルウェアとして認証を追加
- フロントからアクセストークンを渡して、supabase-authで認証

## フロントエンド

- TODO作成機能を改善し、状態管理を追加。
- クライアントの認証処理を整理し、API呼び出しを最適化。