### PR TITLE
`todos`テーブルに`status`フィールドを追加

### DIFF
--- a/apps/backend/drizzle/0001_regular_moonstone.sql
+++ b/apps/backend/drizzle/0001_regular_moonstone.sql
@@ -1,0 +1,3 @@
+CREATE TYPE "public"."status" AS ENUM('not started', 'in progress', 'DONE');--> statement-breakpoint
+ALTER TABLE "todos" ADD COLUMN "status" "status" DEFAULT 'not started';--> statement-breakpoint
+ALTER TABLE "todos" ADD COLUMN "updated_at" timestamp DEFAULT now() NOT NULL;

--- a/apps/backend/drizzle/meta/0001_snapshot.json
+++ b/apps/backend/drizzle/meta/0001_snapshot.json
@@ -1,0 +1,148 @@
+{
+  "id": "6cb4bcfa-b000-443f-b7c3-e521c3f8f643",
+  "prevId": "939bf7d0-6b15-42a4-ad03-2171b08858b1",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.profile": {
+      "name": "profile",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(25)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "profile_id_users_id_fk": {
+          "name": "profile_id_users_id_fk",
+          "tableFrom": "profile",
+          "tableTo": "users",
+          "schemaTo": "auth",
+          "columnsFrom": [
+            "id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.todos": {
+      "name": "todos",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'not started'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "todos_profile_id_profile_id_fk": {
+          "name": "todos_profile_id_profile_id_fk",
+          "tableFrom": "todos",
+          "tableTo": "profile",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.status": {
+      "name": "status",
+      "schema": "public",
+      "values": [
+        "not started",
+        "in progress",
+        "DONE"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/backend/drizzle/meta/_journal.json
+++ b/apps/backend/drizzle/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1749673042623,
       "tag": "0000_sharp_stephen_strange",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1750404280618,
+      "tag": "0001_regular_moonstone",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/backend/src/db/schema.ts
+++ b/apps/backend/src/db/schema.ts
@@ -1,13 +1,12 @@
 import { relations } from "drizzle-orm";
-import {
-  integer,
-  pgTable,
-  pgSchema,
-  uuid,
-  varchar,
-  timestamp,
-} from "drizzle-orm/pg-core";
+import { pgTable, uuid, varchar, timestamp, pgEnum } from "drizzle-orm/pg-core";
 import { authUsers } from "drizzle-orm/supabase";
+
+export const statusEnum = pgEnum("status", [
+  "not started",
+  "in progress",
+  "DONE",
+]);
 
 // Profile テーブル（auth.users に対する 1:1 マッピング）
 export const Profile = pgTable("profile", {
@@ -26,7 +25,9 @@ export const Todos = pgTable("todos", {
     .references(() => Profile.id),
   title: varchar("title", { length: 255 }).notNull(),
   description: varchar("description", { length: 255 }),
+  status: statusEnum().default("not started"),
   createdAt: timestamp("created_at").notNull().defaultNow(),
+  updatedAt: timestamp("updated_at").notNull().defaultNow(),
 });
 
 // リレーション定義


### PR DESCRIPTION
## `todos`テーブルに`status`フィールドを追加

```
export const statusEnum = pgEnum("status", [
  "not started",
  "in progress",
  "DONE",
]);
```

![image](https://github.com/user-attachments/assets/88321d7c-8add-476e-9479-1cf05d7b2f7c)