### PR TITLE
ステータスをステート管理するように修正

### DIFF
--- a/apps/frontend/src/components/TodoItem.tsx
+++ b/apps/frontend/src/components/TodoItem.tsx
@@ -68,7 +68,7 @@ export const TodoItem = ({ todo }: TodoPostResponse) => {
       >
         {todo.title}
       </label>
-      <StatusBadge status={todo.status} todo={todo} />
+      <StatusBadge currentStatus={todo.status} todo={todo} />
       <Button
         variant="ghost"
         size="icon"

--- a/apps/frontend/src/components/custom/StatusBadge.tsx
+++ b/apps/frontend/src/components/custom/StatusBadge.tsx
@@ -11,10 +11,15 @@ import {
 import { useUpdateTodo } from "@/features/todos/api/use-update-todos";
 import { Todo } from "@/types/api";
 import { toast } from "sonner";
+import { useState } from "react";
 
 // ステータスの文字列リテラル型
 type TodoStatus = "NOT_STARTED" | "IN_PROGRESS" | "DONE";
-
+type Config = {
+  label: string;
+  badgeClass: string;
+  dotClass: string;
+};
 // ステータスごとの設定を定義するオブジェクト
 const statusConfig: Record<
   TodoStatus,
@@ -48,14 +53,17 @@ const statusConfig: Record<
 // Props
 interface StatusBadgeProps {
   todo: Todo;
-  status: TodoStatus;
+  currentStatus: TodoStatus;
   className?: string;
 }
 
-export const StatusBadge = ({ todo, status, className }: StatusBadgeProps) => {
+export const StatusBadge = ({
+  todo,
+  currentStatus,
+  className,
+}: StatusBadgeProps) => {
   const { mutate } = useUpdateTodo();
-  const config = statusConfig[status];
-
+  const [config, setConfig] = useState<Config>(statusConfig[currentStatus]);
   // 不正なステータスが渡された場合は何も表示しない
   if (!config) {
     return null;
@@ -64,6 +72,7 @@ export const StatusBadge = ({ todo, status, className }: StatusBadgeProps) => {
     (s) => s !== status
   );
   const changeStatus = (newStatus: TodoStatus) => {
+    setConfig(statusConfig[newStatus]);
     mutate(
       {
         id: todo.id,

--- a/apps/frontend/src/features/todos/api/use-update-todos.ts
+++ b/apps/frontend/src/features/todos/api/use-update-todos.ts
@@ -1,4 +1,4 @@
-import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useMutation } from "@tanstack/react-query";
 import { updateTodo } from "../action";
 import { TodosPatchResponse } from "@/types/api";
 
@@ -10,16 +10,11 @@ type UpdateTodoVariables = {
 };
 
 export const useUpdateTodo = () => {
-  const queryClient = useQueryClient();
-
   return useMutation<TodosPatchResponse, Error, UpdateTodoVariables>({
     mutationFn: async (variables: UpdateTodoVariables) => {
       const newTodoData = { json: { ...variables } };
       const response = await updateTodo(newTodoData);
       return response;
-    },
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["todos"] });
     },
   });
 };


### PR DESCRIPTION
## 実装内容

### 課題

- ステータス変更時に、tan-stack-queryでtodo配列を更新して、変更を反映していたがそれだと毎回Todo取得のAPIを叩いて、反映させていて遅いし、無駄な処理である

### 解決方法

- ステータス変更＞バックエンドで変更、フロントではステートで変更を表示するように修正