### PR TITLE
パンくずリストコンポーネントを追加

### DIFF
--- a/apps/frontend/src/app/mypage/edit/page.tsx
+++ b/apps/frontend/src/app/mypage/edit/page.tsx
@@ -7,16 +7,7 @@ import { useSearchParams } from "next/navigation";
 import { useActionState, useRef, useState } from "react";
 import { toast } from "sonner";
 import { usePatchProfile } from "@/features/profile/api/use-patch-profile";
-import {
-  Breadcrumb,
-  BreadcrumbItem,
-  BreadcrumbLink,
-  BreadcrumbList,
-  BreadcrumbPage,
-  BreadcrumbSeparator,
-} from "@/components/ui/breadcrumb";
-import { SlashIcon } from "lucide-react";
-import Link from "next/link";
+import { BreadcrumbComponent } from "@/components/Breadcrumb";
 
 type FormState = {
   message: string;
@@ -28,6 +19,21 @@ const initialState: FormState = {
   isSuccess: false,
 };
 
+const breadcrumbProps = {
+  child: [
+    {
+      path: "/",
+      title: "Home",
+    },
+    {
+      path: "/mypage",
+      title: "My Page",
+    },
+  ],
+  noChild: {
+    title: "Edit Profile",
+  },
+};
 export default function MyPage() {
   const { mutate } = usePatchProfile();
   const searchParams = useSearchParams();
@@ -64,35 +70,12 @@ export default function MyPage() {
   const [, submitAction, isPending] = useActionState(formAction, initialState);
 
   return (
-    <div className="relative w-full max-w-4xl min-h-screen text-white px-6 py-12 flex flex-col items-center justify-center">
-      <Breadcrumb className="absolute left-6 top-12">
-        <BreadcrumbList>
-          <BreadcrumbItem>
-            <BreadcrumbLink asChild>
-              <Link href="/" className="text-zinc-400 hover:text-white">
-                Home
-              </Link>
-            </BreadcrumbLink>
-          </BreadcrumbItem>
-          <BreadcrumbSeparator>
-            <SlashIcon />
-          </BreadcrumbSeparator>
-          <BreadcrumbItem>
-            <BreadcrumbLink asChild>
-              <Link href="/mypage" className="text-zinc-400 hover:text-white">
-                Mypage
-              </Link>
-            </BreadcrumbLink>
-          </BreadcrumbItem>
-          <BreadcrumbSeparator>
-            <SlashIcon />
-          </BreadcrumbSeparator>
-          <BreadcrumbItem>
-            <BreadcrumbPage className="text-white">edit</BreadcrumbPage>
-          </BreadcrumbItem>
-        </BreadcrumbList>
-      </Breadcrumb>
-      <div className="w-full space-y-8">
+    <div className="relative w-full min-h-screen text-white px-6 py-12 flex flex-col items-center justify-center">
+      <BreadcrumbComponent
+        child={breadcrumbProps.child}
+        noChild={breadcrumbProps.noChild}
+      />
+      <div className="w-full max-w-4xl space-y-8">
         <Card className="bg-gradient-to-br from-zinc-900 via-black to-zinc-800 backdrop-blur-md border border-zinc-700 rounded-2xl shadow-xl transition hover:shadow-2xl">
           <CardContent className="mt-4 space-y-6">
             <h1 className="text-zinc-400 uppercase text-l mb-1">

--- a/apps/frontend/src/app/mypage/page.tsx
+++ b/apps/frontend/src/app/mypage/page.tsx
@@ -7,6 +7,19 @@ import { useGetProfile } from "@/features/profile/api/use-get-profile";
 import { redirect } from "next/navigation";
 import { toast } from "sonner";
 import { Loading } from "@/components/Loading";
+import { BreadcrumbComponent } from "@/components/Breadcrumb";
+
+const breadcrumbProps = {
+  child: [
+    {
+      path: "/",
+      title: "Home",
+    },
+  ],
+  noChild: {
+    title: "My Page",
+  },
+};
 
 export default function MyPage() {
   const { data, isLoading } = useGetProfile();
@@ -19,6 +32,10 @@ export default function MyPage() {
   }
   return (
     <div className="w-full max-w-4xl min-h-screen text-white px-6 py-12 flex flex-col items-center justify-center">
+      <BreadcrumbComponent
+        child={breadcrumbProps.child}
+        noChild={breadcrumbProps.noChild}
+      />
       <div className="w-full space-y-8">
         <header className="text-center bg-black border border-zinc-700 py-4">
           <h1 className="text-4xl font-bold tracking-tight">My Page</h1>

--- a/apps/frontend/src/components/Breadcrumb.tsx
+++ b/apps/frontend/src/components/Breadcrumb.tsx
@@ -1,0 +1,55 @@
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from "@/components/ui/breadcrumb";
+import { SlashIcon } from "lucide-react";
+import Link from "next/link";
+
+type BreadcrumbChildItem = {
+  path: string;
+  title: string;
+};
+type BreadcrumbItem = {
+  title: string;
+};
+type BreadcrumbProps = {
+  child: BreadcrumbChildItem[];
+  noChild: BreadcrumbItem;
+};
+export const BreadcrumbComponent = ({ child, noChild }: BreadcrumbProps) => {
+  if (child == null || noChild == null) return null;
+  return (
+    <Breadcrumb className="absolute left-6 top-12">
+      <BreadcrumbList>
+        {child.map((item: BreadcrumbChildItem) => {
+          return (
+            <>
+              <BreadcrumbItem>
+                <BreadcrumbLink asChild>
+                  <Link
+                    href={item.path}
+                    className="text-zinc-400 hover:text-white"
+                  >
+                    {item.title}
+                  </Link>
+                </BreadcrumbLink>
+              </BreadcrumbItem>
+              <BreadcrumbSeparator>
+                <SlashIcon />
+              </BreadcrumbSeparator>
+            </>
+          );
+        })}
+        <BreadcrumbItem>
+          <BreadcrumbPage className="text-white">
+            {noChild.title}
+          </BreadcrumbPage>
+        </BreadcrumbItem>
+      </BreadcrumbList>
+    </Breadcrumb>
+  );
+};


### PR DESCRIPTION
## パンくずリストコンポーネントを追加

- パンくずリストをコンポーネントとしてリファクタし、マイページにもリストを追加
- リストのパスやリスト名はプロップスとして渡すように修正